### PR TITLE
refactor: decouple collisions between objects

### DIFF
--- a/Assets/Prefabs/Asteroid.prefab
+++ b/Assets/Prefabs/Asteroid.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 256606015}
   m_Layer: 0
   m_Name: Asteroid
-  m_TagString: Untagged
+  m_TagString: Asteroid
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Enemy/Enemy.prefab
+++ b/Assets/Prefabs/Enemy/Enemy.prefab
@@ -51,6 +51,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 4
   explosionAudioClip: {fileID: 8300000, guid: a885c043fab7e46438bba03ba9dab6bc, type: 3}
+  destroyedByLaserEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!212 &5738935044905097677
 SpriteRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Powerup/ShieldPowerup.prefab
+++ b/Assets/Prefabs/Powerup/ShieldPowerup.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 3627859771990562947}
   m_Layer: 0
   m_Name: ShieldPowerup
-  m_TagString: Untagged
+  m_TagString: Powerup
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Powerup/SpeedPowerup.prefab
+++ b/Assets/Prefabs/Powerup/SpeedPowerup.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 8800686652266317036}
   m_Layer: 0
   m_Name: SpeedPowerup
-  m_TagString: Untagged
+  m_TagString: Powerup
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Powerup/TripleShotPowerup.prefab
+++ b/Assets/Prefabs/Powerup/TripleShotPowerup.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 9137917969101579550}
   m_Layer: 0
   m_Name: TripleShotPowerup
-  m_TagString: Untagged
+  m_TagString: Powerup
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1215,6 +1215,21 @@ MonoBehaviour:
   - {fileID: 251085121047806414, guid: e2e2e32fadc7441ceb0f3e5ec0a5e024, type: 3}
   - {fileID: 3068279347205884460, guid: eeb634f1a756e41ea8968c3583d59564, type: 3}
   - {fileID: 2879910642300908349, guid: 669cc2176cce441c680e69468c035f5a, type: 3}
+  enemyReportedScoreEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2041227466}
+        m_TargetAssemblyTypeName: Player, Assembly-CSharp
+        m_MethodName: IncreaseScore
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!4 &1375580764
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Asteroid.cs
+++ b/Assets/Scripts/Asteroid.cs
@@ -10,10 +10,14 @@ public class Asteroid : MonoBehaviour
     private GameObject explosionPrefab;
 
     private SpawnManager spawnManager;
+    private Collider2D myCollider;
+
+    public const string TAG = "Asteroid";
 
     void Start()
     {
         spawnManager = GameObject.Find("Spawn Manager").GetComponent<SpawnManager>();
+        myCollider = GetComponent<CircleCollider2D>();
     }
 
     // Update is called once per frame
@@ -24,10 +28,10 @@ public class Asteroid : MonoBehaviour
 
     void OnTriggerEnter2D(Collider2D other)
     {
-        if (other.tag == "Laser")
+        if (other.CompareTag(Laser.TAG))
         {
+            myCollider.enabled = false;
             Instantiate(explosionPrefab, transform.position, Quaternion.identity);
-            Destroy(other.gameObject);
             spawnManager.StartSpawning();
             Destroy(gameObject, 0.15f);
         }

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class Enemy : MonoBehaviour
 {
@@ -8,24 +9,26 @@ public class Enemy : MonoBehaviour
     private float speed = 4.0f;
     [SerializeField]
     private AudioClip explosionAudioClip;
+    [SerializeField]
+    public UnityEvent<int> destroyedByLaserEvent;
 
     private float maxY = 8.0f;
     private float minY = -5.7f;
     private float maxX = 8.0f;
     private float minX = -8.0f;
 
-    private bool isDestroyed = false;
-
-    private Player player;
     private Animator animator;
     private AudioSource audioSource;
+    private BoxCollider2D boxCollider;
+
+    public const string TAG = "Enemy";
 
     // Start is called before the first frame update
     void Start()
     {
-        player = GameObject.Find("Player").GetComponent<Player>();
         animator = GetComponent<Animator>();
         audioSource = GetComponent<AudioSource>();
+        boxCollider = GetComponent<BoxCollider2D>();
         audioSource.clip = explosionAudioClip;
     }
 
@@ -41,7 +44,7 @@ public class Enemy : MonoBehaviour
         transform.Translate(speed * Time.deltaTime * Vector3.down);
 
         // Respawn at top in new random X position
-        if (transform.position.y < minY && !isDestroyed)
+        if (transform.position.y < minY && boxCollider.enabled)
         {
             float x = Random.Range(minX, maxX);
             transform.position = new(x, maxY, transform.position.z);
@@ -50,26 +53,21 @@ public class Enemy : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (!isDestroyed)
+        switch (other.tag)
         {
-            switch (other.tag)
-            {
-                case "Player":
-                    other.GetComponent<Player>().Damage();
-                    DestroySelf();
-                    break;
-                case "Laser":
-                    Destroy(other.gameObject);
-                    player.IncreaseScore(10);
-                    DestroySelf();
-                    break;
-            }
+            case Player.TAG:
+                DestroySelf();
+                break;
+            case Laser.TAG:
+                destroyedByLaserEvent.Invoke(10);
+                DestroySelf();
+                break;
         }
     }
 
     void DestroySelf()
     {
-        isDestroyed = true;
+        boxCollider.enabled = false;
         animator.SetTrigger("OnEnemyDeath");
         audioSource.Play();
         Destroy(gameObject, 2.8f);

--- a/Assets/Scripts/Laser.cs
+++ b/Assets/Scripts/Laser.cs
@@ -9,6 +9,8 @@ public class Laser : MonoBehaviour
 
     private float maxY = 8.0f;
 
+    public const string TAG = "Laser";
+
     // Update is called once per frame
     void Update()
     {
@@ -33,6 +35,17 @@ public class Laser : MonoBehaviour
             {
                 Destroy(gameObject);
             }
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        switch (other.tag)
+        {
+            case Enemy.TAG:
+            case Asteroid.TAG:
+                Destroy(gameObject);
+                break;
         }
     }
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -46,6 +46,8 @@ public class Player : MonoBehaviour
     private Coroutine previousTripleshotCoroutine;
     private Coroutine previousSpeedCoroutine;
 
+    public const string TAG = "Player";
+
     // Start is called before the first frame update
     void Start()
     {
@@ -129,7 +131,7 @@ public class Player : MonoBehaviour
         #endif
     }
 
-    public void Damage()
+    private void Damage()
     {
         if (shield.activeSelf)
         {
@@ -151,7 +153,38 @@ public class Player : MonoBehaviour
         }
     }
 
-    public void EnableTripleShot()
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        switch (other.tag)
+        {
+            case Enemy.TAG:
+                Damage();
+                break;
+            case Powerup.TAG:
+                var powerup = other.GetComponent<Powerup>();
+                ApplyPowerup(powerup.Type);
+                break;
+        }
+    }
+
+    private void ApplyPowerup(PowerupType powerupType)
+    {
+        switch (powerupType)
+        {
+            case PowerupType.TripleShot:
+                EnableTripleShot();
+                break;
+            case PowerupType.Speed:
+                EnableSpeedBoost();
+                break;
+            case PowerupType.Shield:
+                EnableShield();
+                break;
+        }
+
+    }
+
+    private void EnableTripleShot()
     {
         if (previousTripleshotCoroutine != null)
         {
@@ -161,7 +194,7 @@ public class Player : MonoBehaviour
         previousTripleshotCoroutine = StartCoroutine(PowerDownRoutine(() => isTripleShotActive = false));
     }
 
-    public void EnableSpeedBoost()
+    private void EnableSpeedBoost()
     {
         if (previousSpeedCoroutine != null)
         {
@@ -171,7 +204,7 @@ public class Player : MonoBehaviour
         previousSpeedCoroutine = StartCoroutine(PowerDownRoutine(() => speedBoostFactor = 1.0f));
     }
 
-    public void EnableShield()
+    private void EnableShield()
     {
         shield.SetActive(true);
     }

--- a/Assets/Scripts/Powerup.cs
+++ b/Assets/Scripts/Powerup.cs
@@ -8,10 +8,13 @@ public class Powerup : MonoBehaviour
     private float speed = 3.0f;
     [SerializeField]
     private PowerupType type;
+    public PowerupType Type => type;
     [SerializeField]
     private AudioClip collectedAudioClip;
 
     private float minY = -5.7f;
+
+    public const string TAG = "Powerup";
 
     // Update is called once per frame
     void Update()
@@ -27,38 +30,13 @@ public class Powerup : MonoBehaviour
     private void OnTriggerEnter2D(Collider2D other)
     {
         // Only ever consider player collisions
-        if (!other.CompareTag("Player"))
+        if (!other.CompareTag(Player.TAG))
         {
             return;
         }
 
-        // Apply power-up and destroy object
-        var player = other.GetComponent<Player>();
-        if (player != null)
-        {
-            Debug.Log(type + " powerup collected!");
-            switch (type)
-            {
-                case PowerupType.TripleShot:
-                    player.EnableTripleShot();
-                    break;
-                case PowerupType.Speed:
-                    player.EnableSpeedBoost();
-                    break;
-                case PowerupType.Shield:
-                    player.EnableShield();
-                    break;
-            }
-        }
-
+        // Play pick-up sound and destroy object
         AudioSource.PlayClipAtPoint(collectedAudioClip, transform.position);
         Destroy(gameObject);
-    }
-
-    enum PowerupType
-    {
-        TripleShot,
-        Speed,
-        Shield,
     }
 }

--- a/Assets/Scripts/PowerupType.cs
+++ b/Assets/Scripts/PowerupType.cs
@@ -1,0 +1,10 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum PowerupType
+{
+    TripleShot,
+    Speed,
+    Shield,
+}

--- a/Assets/Scripts/PowerupType.cs.meta
+++ b/Assets/Scripts/PowerupType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4c93e3bf997d41ac922c166354a368c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SpawnManager.cs
+++ b/Assets/Scripts/SpawnManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class SpawnManager : MonoBehaviour
 {
@@ -8,6 +9,8 @@ public class SpawnManager : MonoBehaviour
     private GameObject enemyPrefab;
     [SerializeField]
     private GameObject[] powerUpPrefabs;
+    [SerializeField]
+    private UnityEvent<int> enemyReportedScoreEvent;
 
     private bool stopSpawning = false;
 
@@ -29,7 +32,12 @@ public class SpawnManager : MonoBehaviour
         {
             // Spawn at a random x position
             float x = Random.Range(minX, maxX);
+
+            // Wire up events between enemy and configured event receiver
             GameObject enemy = Instantiate(enemyPrefab, new Vector3(x, maxY, 0), Quaternion.identity);
+            enemy.GetComponent<Enemy>().destroyedByLaserEvent.AddListener(
+                score => enemyReportedScoreEvent.Invoke(score)
+            );
 
             // Group enemies under the spawn manager
             enemy.transform.parent = gameObject.transform;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,8 @@ TagManager:
   tags:
   - Enemy
   - Laser
+  - Asteroid
+  - Powerup
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
This change splits collision behavior apart so that each entity capable of collisions (e.g., the player, lasers, enemies, and the asteroid) handles its own behavioral changes for each supported collision pair.

For example, prior to this change, the `Enemy` class held an instance of `Player` as a member variable for the purposes of invoking `Damage()` on when a player collides with an enemy.

After this change, the `Player` is responsible for invoking its own `Damage()` method as it now handles the enemy collision logic internally, while an `Enemy` instance only takes care of destroying itself while handling the player collision event independently.